### PR TITLE
Avoid mix content issue when visiting the blog over https

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ words_per_minute: 200
 # Your site's domain goes here (eg: //mmistakes.github.io, http://mademistakes.com, etc)
 # When testing locally leave blank or use http://localhost:4000
 #
-url: http://corb3nik.github.io
+url: //corb3nik.github.io
 
 # draw your top menu here
 # each item must have a title and a url.


### PR DESCRIPTION
I saw your blog being linked with `https://` and the CSS was not loaded.

https://twitter.com/pwntester/status/740294490548666369
